### PR TITLE
fix : 통신 안되던 부분 수정

### DIFF
--- a/src/main/java/com/challenge/chat/config/SecurityConfig.java
+++ b/src/main/java/com/challenge/chat/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
 			// 아이콘, css, js 관련
 			// 기본 페이지, css, image, js 하위 폴더에 있는 자료들은 모두 접근 가능, h2-console에 접근 가능
 			.requestMatchers("/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**").permitAll()
-			.requestMatchers("/ws/**").permitAll() //웹소캣 통신?
+			.requestMatchers("/ws-edit/**").permitAll() //웹소캣 통신?
 			.anyRequest().authenticated() // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능
 			.and()
 			//== 소셜 로그인 설정 ==//

--- a/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
@@ -22,7 +22,6 @@ import com.challenge.chat.domain.chat.dto.ChatRoomDto;
 import com.challenge.chat.domain.chat.dto.EnterUserDto;
 import com.challenge.chat.domain.chat.service.ChatService;
 import com.challenge.chat.global.dto.ResponseDto;
-import com.challenge.chat.security.oauth.dto.CustomOAuth2User;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,8 +45,8 @@ public class ChatController {
 
 	@GetMapping("/chat/{roomId}")
 	public EnterUserDto findChatRoom(@PathVariable String roomId,
-		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-		return chatService.findRoom(roomId, customOAuth2User.getEmail());
+		@AuthenticationPrincipal User user) {
+		return chatService.findRoom(roomId, user.getUsername());
 	}
 
 	@MessageMapping("/chat/enter")

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
@@ -16,7 +16,7 @@ public class ChatDto {
 
 	private MessageType type;
 	private String sender;
-	private String email;
+	private String userId;
 	private String roomId;
 	private String date;
 	private String message;
@@ -24,7 +24,7 @@ public class ChatDto {
 	public ChatDto(Chat chat) {
 		this.type = chat.getType();
 		this.sender = chat.getSender();
-		this.email = chat.getEmail();
+		this.userId = chat.getEmail();
 		this.roomId = chat.getRoom().getRoomId();
 		this.message = chat.getMessage();
 	}

--- a/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
@@ -66,11 +66,11 @@ public class ChatService {
 		ChatRoom chatRoom = validExistChatRoom(chatDto.getRoomId());
 		// 예외처리
 		//반환 결과를 socket session에 사용자의 id로 저장
-		Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("userId", chatDto.getEmail());
+		Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("userId", chatDto.getUserId());
 		headerAccessor.getSessionAttributes().put("roomId", chatDto.getRoomId());
 		headerAccessor.getSessionAttributes().put("nickName", chatDto.getSender());
 
-		Member member = userIDCheck(chatDto.getEmail());
+		Member member = userIDCheck(chatDto.getUserId());
 		ChatRoom room = roomIdCheck(chatDto.getRoomId());
 		member.enterRoom(room);
 
@@ -93,7 +93,7 @@ public class ChatService {
 			.type(MessageType.LEAVE)
 			.roomId(roomId)
 			.sender(nickName)
-			.email(userId)
+			.userId(userId)
 			.message(nickName + "님 퇴장!! ヽ(*。>Д<)o゜")
 			.build();
 
@@ -159,7 +159,7 @@ public class ChatService {
 	public void sendChatRoom(ChatDto chatDto, SimpMessageHeaderAccessor headerAccessor) {
 
 		ChatRoom room = roomIdCheck(chatDto.getRoomId());
-		Member member = userIDCheck(chatDto.getEmail());
+		Member member = userIDCheck(chatDto.getUserId());
 		MessageType type = MessageType.TALK;
 
 		Date date = new Date();


### PR DESCRIPTION
1. fix : ChatDto 수정 email -> userId

      프론트에서 userId로 값을 넣어주고 있는데,
      Dto에서 userId가 존재하지 않음.



2. fix: SecurityConfig웹소캣 부분 열어주기

      WebSocket은 연결 시 먼저 Http요청을 통해 연결하는
      핸드쉐이크 요청을 한다.

      핸드쉐이크 응답은 101코드로 응답을 하며,
      프로토콜이 HTTP에서 WebSocket으로 바뀌게 된다.

      따라서 웹 소캣에서는 사용자들이 미리 인증을 받았다고 판단한다.

![image](https://github.com/god-kao-talk/chat-challenge-BE/assets/80087131/6d20dea3-9dd9-4d96-82c8-2b924a9e656a)

참고: 
1: https://velog.io/@tlatldms/Spring-Boot-STOMP-JWT-Socket-%EC%9D%B8%EC%A6%9D%ED%95%98%EA%B8%B0
2: https://velog.io/@kmh916/Spring-Boot-%EC%B1%84%ED%8C%85-%EA%B5%AC%ED%98%84SockJSStomp-0.-WebSocketSockJSStomp-%EB%9E%80