### PR TITLE
refactor : 채팅 관련 API 및 비즈니스 로직 리팩토링

### DIFF
--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
@@ -6,14 +6,14 @@ import com.challenge.chat.domain.chat.entity.MessageType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.format.DateTimeFormatter;
 
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class ChatDto {
 
 	private MessageType type;
@@ -23,11 +23,21 @@ public class ChatDto {
 	private String date;
 	private String message;
 
-	public ChatDto(Chat chat) {
-		this.type = chat.getType();
-		this.sender = chat.getMember().getNickname();
-		this.userId = chat.getMember().getEmail();
-		this.roomId = chat.getRoom().getRoomId();
-		this.message = chat.getMessage();
+	public ChatDto(MessageType type, String sender, String userId, String roomId, String message) {
+		this.type = type;
+		this.sender = sender;
+		this.userId = userId;
+		this.roomId = roomId;
+		this.message = message;
+	}
+
+	public static ChatDto from(Chat chat) {
+		return new ChatDto(
+			chat.getType(),
+			chat.getMember().getNickname(),
+			chat.getMember().getEmail(),
+			chat.getRoom().getRoomId(),
+			chat.getMessage()
+		);
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatRoomDto.java
@@ -1,7 +1,10 @@
 package com.challenge.chat.domain.chat.dto;
 
+import java.util.UUID;
+
 import com.challenge.chat.domain.chat.entity.ChatRoom;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,14 +12,20 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ChatRoomDto {
 	private Long id;
 	private String roomId;
 	private String roomName;
 
-	public ChatRoomDto(ChatRoom chatRoom) {
-		this.id = chatRoom.getId();
-		this.roomId = chatRoom.getRoomId();
-		this.roomName = chatRoom.getRoomName();
+	public static ChatRoomDto from(ChatRoom chatRoom) {
+		return new ChatRoomDto(chatRoom.getId(), chatRoom.getRoomId(), chatRoom.getRoomName());
+	}
+
+	public static ChatRoom toEntity(ChatRoomDto dto) {
+		return ChatRoom.of(
+			UUID.randomUUID().toString(),
+			dto.getRoomName()
+		);
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/ChatRoom.java
@@ -2,7 +2,6 @@ package com.challenge.chat.domain.chat.entity;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import com.challenge.chat.global.entity.TimeStamped;
 
@@ -13,14 +12,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class ChatRoom extends TimeStamped {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,8 +33,12 @@ public class ChatRoom extends TimeStamped {
 	@OneToMany(mappedBy = "room", orphanRemoval = true, cascade = CascadeType.ALL)
 	private List<MemberChatRoom> memberList = new ArrayList<>();
 
-	public ChatRoom(String roomName) {
-		this.roomId = UUID.randomUUID().toString();
+	private ChatRoom(String roomId, String roomName) {
+		this.roomId = roomId;
 		this.roomName = roomName;
+	}
+
+	public static ChatRoom of(String roomId, String roomName) {
+		return new ChatRoom(roomId, roomName);
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
@@ -77,6 +77,7 @@ public class ChatService {
 	}
 
 	// 채팅방 나가기
+	@Transactional(readOnly = true)
 	public ChatDto leaveChatRoom(SimpMessageHeaderAccessor headerAccessor) {
 		log.info("Service 채팅방 나가기");
 
@@ -94,6 +95,7 @@ public class ChatService {
 	}
 
 	// 채팅 메세지 조회
+	@Transactional(readOnly = true)
 	public EnterUserDto viewChat(String roomId, String email) {
 		log.info("Service 채팅방 메세지 조회");
 

--- a/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
@@ -13,7 +13,8 @@ import com.challenge.chat.domain.chat.repository.MemberChatRoomRepository;
 import com.challenge.chat.domain.member.entity.Member;
 import com.challenge.chat.domain.member.repository.MemberRepository;
 import com.challenge.chat.domain.member.service.MemberService;
-import com.challenge.chat.global.dto.ResponseDto;
+import com.challenge.chat.exception.RestApiException;
+import com.challenge.chat.exception.dto.ChatErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,76 +38,71 @@ public class ChatService {
 	private final MemberService memberService;
 
 	// 채팅방 조회
+	@Transactional(readOnly = true)
 	public List<ChatRoomDto> showRoomList() {
 		log.info("Service 채팅방 조회");
-		List<ChatRoom> chatRoomList = chatRoomRepository.findAll();
-		List<ChatRoomDto> chatRoomDtoList = new ArrayList<>();
-		for (ChatRoom chatRoom : chatRoomList) {
-			ChatRoomDto chatRoomDto = new ChatRoomDto(chatRoom);
-			chatRoomDtoList.add(chatRoomDto);
-		}
-		return chatRoomDtoList;
+
+		// TODO : 내가 구독한 채팅방만 표출되게 변경하기
+		return chatRoomRepository.findAll()
+			.stream()
+			.map(ChatRoomDto::from)
+			.collect(Collectors.toList());
 	}
 
 	// 채팅방 생성
-	public ResponseDto<String> createChatRoom(ChatRoomDto chatRoomDto) {
+	public String createChatRoom(ChatRoomDto chatRoomDto) {
 		log.info("Service 채팅방 생성");
-		ChatRoom newChatRoom = new ChatRoom(chatRoomDto.getRoomName());
-		chatRoomRepository.save(newChatRoom);
-		return ResponseDto.setSuccess("create ChatRoom success", newChatRoom.getRoomId());
+
+		chatRoomRepository.save(ChatRoomDto.toEntity(chatRoomDto));
+		return "Successfully created chat room";
 	}
 
 	// 채팅방 입장
 	public ChatDto enterChatRoom(ChatDto chatDto, SimpMessageHeaderAccessor headerAccessor) {
 		log.info("Service 채팅방 입장");
+
 		ChatRoom chatRoom = getRoomByRoomId(chatDto.getRoomId());
 		Member member = memberService.findMemberByEmail(chatDto.getUserId());
-		// 중간 테이블에 save
-		// 중간 테이블에 이미 연결되어 있다면 새로 생성 안함
+		// 중간 테이블 생성
 		Optional<MemberChatRoom> memberChatRoom = memberChatRoomRepository.findByMemberAndRoom(member, chatRoom);
-
-		if (memberChatRoom.isEmpty()){
+		if (memberChatRoom.isEmpty()) {
 			memberChatRoomRepository.save(new MemberChatRoom(chatRoom, member));
 		}
-
 		//반환 결과를 socket session 에 사용자의 id로 저장
-		Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("userId", chatDto.getUserId());
-		headerAccessor.getSessionAttributes().put("roomId", chatDto.getRoomId());
-		headerAccessor.getSessionAttributes().put("nickName", chatDto.getSender());
-
+		// Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("userId", chatDto.getUserId());
+		// headerAccessor.getSessionAttributes().put("roomId", chatDto.getRoomId());
+		// headerAccessor.getSessionAttributes().put("nickName", chatDto.getSender());
 		chatDto.setMessage(chatDto.getSender() + "님 입장!! ο(=•ω＜=)ρ⌒☆");
 		return chatDto;
 	}
 
 	// 채팅방 나가기
-	public ChatDto disconnectChatRoom(SimpMessageHeaderAccessor headerAccessor) {
+	public ChatDto leaveChatRoom(SimpMessageHeaderAccessor headerAccessor) {
 		log.info("Service 채팅방 나가기");
+
 		String roomId = (String)headerAccessor.getSessionAttributes().get("roomId");
 		String nickName = (String)headerAccessor.getSessionAttributes().get("nickName");
 		String userId = (String)headerAccessor.getSessionAttributes().get("userId");
 
-		ChatDto chatDto = ChatDto.builder()
+		return ChatDto.builder()
 			.type(MessageType.LEAVE)
 			.roomId(roomId)
 			.sender(nickName)
 			.userId(userId)
 			.message(nickName + "님 퇴장!! ヽ(*。>Д<)o゜")
 			.build();
-
-		return chatDto;
 	}
 
 	// 채팅 메세지 조회
 	public EnterUserDto viewChat(String roomId, String email) {
 		log.info("Service 채팅방 메세지 조회");
+
 		ChatRoom chatRoom = getRoomByRoomId(roomId);
 		Member member = memberService.findMemberByEmail(email);
-		List<Chat> chatList = chatRepository.findAllByRoomIdOrderByCreatedAtAsc(chatRoom.getId());
-		List<ChatDto> chatDtoList = new ArrayList<>();
-		for (Chat chat : chatList) {
-			ChatDto chatDto = new ChatDto(chat);
-			chatDtoList.add(chatDto);
-		}
+		List<ChatDto> chatDtoList = chatRepository.findAllByRoomIdOrderByCreatedAtAsc(chatRoom.getId())
+			.stream()
+			.map(ChatDto::from)
+			.collect(Collectors.toList());
 		return new EnterUserDto(member.getNickname(), member.getEmail(), chatRoom.getRoomId(), chatDtoList);
 	}
 
@@ -128,7 +125,7 @@ public class ChatService {
 
 	public ChatRoom getRoomByRoomId(String roomId) {
 		return chatRoomRepository.findByRoomId(roomId).orElseThrow(
-			() -> new IllegalArgumentException("존재하지 않는 채팅방입니다.")
+			() -> new RestApiException(ChatErrorCode.CHATROOM_NOT_FOUND)
 		);
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/member/service/MemberService.java
+++ b/src/main/java/com/challenge/chat/domain/member/service/MemberService.java
@@ -3,13 +3,15 @@ package com.challenge.chat.domain.member.service;
 import com.challenge.chat.domain.member.dto.MemberDto;
 import com.challenge.chat.domain.member.entity.Member;
 import com.challenge.chat.domain.member.repository.MemberRepository;
+import com.challenge.chat.exception.RestApiException;
+import com.challenge.chat.exception.dto.MemberErrorCode;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -44,11 +46,11 @@ public class MemberService {
     // 공통 메서드
     public Member findMemberByEmail(String email) {
         return memberRepository.findByEmail(email).orElseThrow(
-                () -> new NoSuchElementException("존재하지 않는 유저입니다."));
+                () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
     public Member findMemberById(long userId){
         return memberRepository.findById(userId).orElseThrow(
-                () -> new NoSuchElementException("존재하지 않는 유저입니다."));
+                () -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/challenge/chat/exception/dto/ChatErrorCode.java
+++ b/src/main/java/com/challenge/chat/exception/dto/ChatErrorCode.java
@@ -1,0 +1,17 @@
+package com.challenge.chat.exception.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode implements ErrorCode {
+
+	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다"),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/test/java/com/challenge/chat/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/challenge/chat/domain/member/service/MemberServiceTest.java
@@ -21,6 +21,7 @@ import com.challenge.chat.domain.member.constant.SocialType;
 import com.challenge.chat.domain.member.dto.MemberDto;
 import com.challenge.chat.domain.member.entity.Member;
 import com.challenge.chat.domain.member.repository.MemberRepository;
+import com.challenge.chat.exception.RestApiException;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -83,7 +84,7 @@ class MemberServiceTest {
 
 		//when, then
 		assertThatThrownBy(() -> memberService.getMemberByEmail(email))
-			.isInstanceOf(NoSuchElementException.class);
+			.isInstanceOf(RestApiException.class);
 	}
 
 	@Test
@@ -114,7 +115,7 @@ class MemberServiceTest {
 
 		//when, then
 		assertThatThrownBy(() -> memberService.findMemberById(id))
-			.isInstanceOf(NoSuchElementException.class);
+			.isInstanceOf(RestApiException.class);
 	}
 
 	private Member setMember(Long id, String email) {


### PR DESCRIPTION
리팩토링시 고려한 점
1. 기존 비즈니스 로직에 대한 변경은 최대한 지양
2. Entity의 public 생성자 이용을 지양, 대신 정적 팩토리 메서드를 이용
3. 코드를 간결하게 함
-> Entity를 DTO로 매핑하는 과정에서 Stream API 사용
4. 컨트롤러에서 응답 값을 ResponseEntity로 통일
-> @RestController를 사용하기 때문에 @ResponseBody 반환을 의도
5. GlobalExceptionHandler 활용
-> 비즈니스 로직에서 발생하는 Exception에 대해서는 커스텀 익셉션을 통한 에러 처리

채팅 관련 부분만 리팩토링 진행, 멤버 관련 부분은 다음에 진행 예정