### PR TITLE
refactor : JPA N+1 문제 해결하기

### DIFF
--- a/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
@@ -29,7 +29,7 @@ public class Chat extends TimeStamped {
 	@Enumerated(EnumType.STRING)
 	private MessageType type;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne
 	@JoinColumn(name = "MEMBER_ID")
 	private Member member;
 

--- a/src/main/java/com/challenge/chat/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/challenge/chat/domain/chat/repository/ChatRepository.java
@@ -3,10 +3,13 @@ package com.challenge.chat.domain.chat.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.challenge.chat.domain.chat.entity.Chat;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
-	List<Chat> findAllByRoomIdOrderByCreatedAtAsc(Long ROOM_ID);
+	@Query("select distinct C from Chat C left join fetch C.member where C.room.id = ?1 order by C.createdAt")
+	List<Chat> findAllByRoomIdOrderByCreatedAtAsc(@Param("id") Long id);
 }


### PR DESCRIPTION
채팅 데이터 조회시 member 필드 때문에 해당 테이블도 조회를 하고 있었는데 이때 N+1 문제가 발생하고 있어 fetch join을 통해 해결