### PR TITLE
fix : build test 오류 수정

### DIFF
--- a/src/main/java/com/challenge/chat/ChatApplication.java
+++ b/src/main/java/com/challenge/chat/ChatApplication.java
@@ -3,16 +3,9 @@ package com.challenge.chat;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableJpaRepositories(basePackages = {
-		"com.challenge.chat.domain.chat.repository.mysql",
-		"com.challenge.chat.domain.member.repository"
-})
-@EnableMongoRepositories(basePackages = "com.challenge.chat.domain.chat.repository.mongo")
 public class ChatApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
@@ -19,6 +19,7 @@ public class ChatDto {
 	private String userId;
 	private String roomId;
 	private String message;
+	@Builder.Default
 	private String date = formatDate();
 
 	// TODO: 사용하지 않는 생성자 삭제여부
@@ -41,7 +42,7 @@ public class ChatDto {
 		);
 	}
 
-	private String formatDate(){
+	public static String formatDate(){
 		Date date = new Date();
 		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 		return format.format(date);

--- a/src/main/java/com/challenge/chat/domain/chat/repository/mongo/ChatRepository.java
+++ b/src/main/java/com/challenge/chat/domain/chat/repository/mongo/ChatRepository.java
@@ -2,11 +2,9 @@ package com.challenge.chat.domain.chat.repository.mongo;
 
 import com.challenge.chat.domain.chat.entity.Chat;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface ChatRepository extends MongoRepository<Chat, String> {
     // Spring Data MongoDB -> https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/
 

--- a/src/main/java/com/challenge/chat/domain/chat/repository/mysql/ChatRoomRepository.java
+++ b/src/main/java/com/challenge/chat/domain/chat/repository/mysql/ChatRoomRepository.java
@@ -1,10 +1,9 @@
 package com.challenge.chat.domain.chat.repository.mysql;
 
-import java.util.Optional;
-
+import com.challenge.chat.domain.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.challenge.chat.domain.chat.entity.ChatRoom;
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 

--- a/src/main/java/com/challenge/chat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/challenge/chat/exception/GlobalExceptionHandler.java
@@ -1,23 +1,13 @@
 package com.challenge.chat.exception;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-
 import com.challenge.chat.exception.dto.CommonErrorCode;
 import com.challenge.chat.exception.dto.ErrorCode;
 import com.challenge.chat.exception.dto.ErrorResponse;
-
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/test/java/com/challenge/chat/ChatApplicationTests.java
+++ b/src/test/java/com/challenge/chat/ChatApplicationTests.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles({"test"})

--- a/src/test/java/com/challenge/chat/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/challenge/chat/domain/chat/service/ChatServiceTest.java
@@ -15,6 +15,7 @@ import com.challenge.chat.domain.member.constant.SocialType;
 import com.challenge.chat.domain.member.entity.Member;
 import com.challenge.chat.domain.member.service.MemberService;
 import com.challenge.chat.exception.RestApiException;
+import com.challenge.chat.exception.dto.ChatErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +23,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 
 import java.util.*;
@@ -31,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ChatServiceTest {
 	@Mock
 	private ChatRepository chatRepository;
@@ -303,14 +307,12 @@ class ChatServiceTest {
 		ChatRoom chatRoom = ChatRoom.of("room UUID1", "room name1");
 
 		//given @Mock Stubbing
-		given(chatRoomRepository.findByRoomId(chatDto.getRoomId())).willReturn(Optional.of(chatRoom));
-		given(memberService.findMemberByEmail(chatDto.getUserId())).willThrow(NoSuchElementException.class);
+		given(chatRoomRepository.findByRoomId(chatDto.getRoomId())).willThrow(new RestApiException(ChatErrorCode.CHATROOM_NOT_FOUND));
 
 		//when, then
 		assertThatThrownBy(() -> chatService.sendChatRoom(chatDto))
-			.isInstanceOf(NoSuchElementException.class);
+			.isInstanceOf(RestApiException.class);
 	}
-
 
 	@Test
 	@DisplayName("roomId로 채팅방 가져오기 성공")

--- a/src/test/java/com/challenge/chat/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/challenge/chat/domain/member/service/MemberServiceTest.java
@@ -1,27 +1,26 @@
 package com.challenge.chat.domain.member.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.exceptions.misusing.PotentialStubbingProblem;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.challenge.chat.domain.member.constant.MemberRole;
 import com.challenge.chat.domain.member.constant.SocialType;
 import com.challenge.chat.domain.member.dto.MemberDto;
 import com.challenge.chat.domain.member.entity.Member;
 import com.challenge.chat.domain.member.repository.MemberRepository;
 import com.challenge.chat.exception.RestApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {


### PR DESCRIPTION
1. Unnecessary Stubbing Exception 은 @MockitoSettings(strictness = Strictness.LENIENT)로 해결했습니다. [관련자료](https://jhkimmm.tistory.com/28)

2. sendChatRoomFail2 test는 sendChatRoom 메서드 내용이 변경됨에 맞게 exception 설정하면서 해결했습니다.

3.ChatDto에 date가 Builder에 파라미터로 존재하지 않아 경고가 뜨는걸 default 설정 해주면서 해결했습니다.

4. EnabledJpaRepositories, EnabledMongoRepositories 를 모두 제거하니 MemberControllerTest 오류가 사라졌습니다. DB를 이중화 했을 때 이렇게 정의하지 않으면 스프링 데이터가 레포지토리를 구분하지 못한다고 하지만 React 환경에서 문제가 없었기 때문에 일단 삭제했습니다. [관련자료](https://godekdls.github.io/Spring%20Data%20R2DBC/workingwithspringdatarepositories/)