### PR TITLE
chore : jib를 이용한 docker build 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,11 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.7'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'com.google.cloud.tools.jib' version '3.2.0'
 }
+
+def dockerUsername = System.getenv('DOCKER_USERNAME')
+def dockerPassword = System.getenv('DOCKER_PASSWORD')
 
 group = 'com.challenge'
 version = '0.0.1-SNAPSHOT'
@@ -16,6 +20,33 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+jib {
+    from {
+        image = 'openjdk:17.0.1-jdk-slim'
+        auth {
+            username = dockerUsername
+            password = dockerPassword
+        }
+    }
+    to {
+        image = 'kimgun95/chat-challenge'
+        tags = ['0.2']
+        auth {
+            username = dockerUsername
+            password = dockerPassword
+        }
+    }
+    container {
+        mainClass = 'com.challenge.chat.ChatApplication'
+        creationTime = 'USE_CURRENT_TIMESTAMP'
+        jvmFlags = ['-Dspring.profiles.active=dev']
+        format = 'OCI'
+        volumes = ['/var/temp']
+//        entrypoint = ['java', '-cp', '/app/resources:/app/classes:/app/libs/*'
+//        , 'com.challenge.chat.ChatApplication']
+    }
 }
 
 dependencies {


### PR DESCRIPTION
도커 이미지를 생성하는 방법은 여러가지가 있습니다.
 1. Dockerfile 이용
 2. Docker Compose 이용
 3. JIB 이용

 JIB를 사용하는 이유는 Docker 환경이 필요하지 않다는 점 입니다.
 Dockerfile, Docker Demon 모두 필요 없으며 java application에 최적화된 방법입니다.
 프로젝트를 도커 이미지로 빌드해 이미지 저장소에 바로 보낼 수도 있습니다.
 명령어는 `./gradlew jib`를 통해 도커 이미지를 생성합니다.

우선 설정만 수정했기에 코드에 다른 영향은 없고 ec2 서버에서도 테스트를 진행해야 하기 때문에 pr 보냅니다.