### PR TITLE
chore : 환경변수 없이 jib build 할 수 있게 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,6 @@ plugins {
     id 'com.google.cloud.tools.jib' version '3.2.0'
 }
 
-def dockerUsername = System.getenv('DOCKER_USERNAME')
-def dockerPassword = System.getenv('DOCKER_PASSWORD')
-
 group = 'com.challenge'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
@@ -25,18 +22,10 @@ repositories {
 jib {
     from {
         image = 'openjdk:17.0.1-jdk-slim'
-        auth {
-            username = dockerUsername
-            password = dockerPassword
-        }
     }
     to {
-        image = 'kimgun95/chat-challenge'
+        image = 'chat-challenge'
         tags = ['0.2']
-        auth {
-            username = dockerUsername
-            password = dockerPassword
-        }
     }
     container {
         mainClass = 'com.challenge.chat.ChatApplication'


### PR DESCRIPTION
기존에 생성한 이미지를 docker hub에 업로드하는 로직으로 인해 계정 정보가 입력이 되었어야 했는데 로컬에 업로드 하는 것으로 변경

이유
1. 각자의 로컬 환경에 '환경 변수'를 입력해야 하는 상황이 발생
2. docker hub에 업로드를 해야 하는 필요성이 없음