### PR TITLE
feat : 채팅방 생성, 내 채팅방 리스트 조회 구현

### DIFF
--- a/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
@@ -4,6 +4,7 @@ import com.challenge.chat.domain.chat.constant.KafkaConstants;
 import com.challenge.chat.domain.chat.dto.ChatDto;
 import com.challenge.chat.domain.chat.dto.ChatRoomDto;
 import com.challenge.chat.domain.chat.dto.EnterUserDto;
+import com.challenge.chat.domain.chat.dto.request.ChatRoomRequest;
 import com.challenge.chat.domain.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,21 +33,27 @@ public class ChatController {
 	private final SimpMessagingTemplate msgOperation;
 	private final KafkaTemplate<String, ChatDto> kafkaTemplate;
 
-	// 채팅방 조회
-	@GetMapping("/room")
-	public ResponseEntity<List<ChatRoomDto>> showRoomList() {
-		log.info("Controller showRoomList, 채팅방 조회 호출");
-		return ResponseEntity.status(HttpStatus.OK)
-			.body(chatService.showRoomList());
+	@PostMapping("/chat")
+	public ResponseEntity<Void> createChatRoom(
+		@RequestBody final ChatRoomRequest request,
+		@AuthenticationPrincipal final User user) {
+
+		log.info("Controller : 채팅방 생성, User의 email은 {} 입니다", user.getUsername());
+		chatService.makeChatRoom(ChatRoomDto.from(request), user);
+
+		return ResponseEntity.status(HttpStatus.OK).body(null);
 	}
 
-	// 채팅방 생성
-	@PostMapping("/chat")
-	public ResponseEntity<String> createChatRoom(@RequestBody ChatRoomDto chatRoomDto, @AuthenticationPrincipal User user) {
-		log.info("Controller createChatRoom, 채팅방 생성 User의 email 입니다. {}", user.getUsername());
+	@GetMapping("/chat/room")
+	public ResponseEntity<List<ChatRoomDto>> showChatRoomList(
+		@AuthenticationPrincipal final User user) {
+
+		log.info("Controller : 채팅방 조회, User의 email은 {} 입니다", user.getUsername());
+
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(chatService.createChatRoom(chatRoomDto));
+			.body(chatService.getChatRoomList(user));
 	}
+
 
 	// 채팅방 채팅 내역 조회
 	@GetMapping("/chat/{roomId}")

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatRoomDto.java
@@ -1,5 +1,6 @@
 package com.challenge.chat.domain.chat.dto;
 
+import com.challenge.chat.domain.chat.dto.request.ChatRoomRequest;
 import com.challenge.chat.domain.chat.entity.ChatRoom;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,6 +17,14 @@ public class ChatRoomDto {
 	private String id;
 	private String roomId;
 	private String roomName;
+
+	private ChatRoomDto(String roomName) {
+		this.roomName = roomName;
+	}
+
+	public static ChatRoomDto from(ChatRoomRequest request) {
+		return new ChatRoomDto(request.getRoomName());
+	}
 
 	public static ChatRoomDto from(ChatRoom chatRoom) {
 		return new ChatRoomDto(chatRoom.getId(), chatRoom.getRoomId(), chatRoom.getRoomName());

--- a/src/main/java/com/challenge/chat/domain/chat/dto/request/ChatRoomRequest.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/request/ChatRoomRequest.java
@@ -1,0 +1,12 @@
+package com.challenge.chat.domain.chat.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ChatRoomRequest {
+	private String roomName;
+}

--- a/src/main/java/com/challenge/chat/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/ChatRoom.java
@@ -7,7 +7,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
-import java.util.Date;
 
 @Document(collection = "chatroom")
 @Getter
@@ -18,7 +17,6 @@ public class ChatRoom {
 
 	private String roomId;
 	private String roomName;
-
 
 	@CreatedDate
 	private Instant createdAt;

--- a/src/main/java/com/challenge/chat/domain/chat/entity/MemberChatRoom.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/MemberChatRoom.java
@@ -1,6 +1,5 @@
 package com.challenge.chat.domain.chat.entity;
 
-import com.challenge.chat.domain.member.entity.Member;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,10 +13,10 @@ public class MemberChatRoom {
 	private String id;
 
 	private String roomId;
-	private String memberId;
+	private String memberEmail;
 
-	public MemberChatRoom(ChatRoom room, Member member) {
-		this.roomId = room.getRoomId();
-		this.memberId = member.getEmail();
+	public MemberChatRoom(String roomId, String email) {
+		this.roomId = roomId;
+		this.memberEmail = email;
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/repository/MemberChatRoomRepository.java
+++ b/src/main/java/com/challenge/chat/domain/chat/repository/MemberChatRoomRepository.java
@@ -3,9 +3,12 @@ package com.challenge.chat.domain.chat.repository;
 import com.challenge.chat.domain.chat.entity.MemberChatRoom;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberChatRoomRepository extends MongoRepository<MemberChatRoom, String> {
 
-	Optional<MemberChatRoom> findByMemberIdAndRoomId(String memberId, String roomId);
+	Optional<MemberChatRoom> findByMemberEmailAndRoomId(String memberId, String roomId);
+
+	Optional<List<MemberChatRoom>> findByMemberEmail(String email);
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,4 +9,4 @@ spring:
   data:
     mongodb:
       uri: ENC(51jeryR5B+N1EuAyH58DjDhs271T71dq18ySle4M4NuB1PA29MatU1ZO/7EtyLLMq5wMcPOVrfnUSAHmOvwXmcuwKFQs5tZRuvB8Vj1Z3gKqT6NNV4HMrBrcNTtx5PXWQurAXIlw/5M=)
-      auto-index-creation=true:
+      auto-index-creation: true


### PR DESCRIPTION
1. 채팅방 생성
기존 : 채팅방 생성이 끝
변경 : 채팅방 생성, 생성한 유저의 정보를 이용해 MemberChatRoom 생성

TODO : 비동기적으로 chatRoom 과 memberchatRoom을 저장하기

2. 채팅방 리스트 조회
기존 : 모든 채팅방 조회
변경 : 유저가 참여하고 있는 채팅방 리스트만 조회
-> 이때 join을 사용할 수 없어 조회 쿼리를 2번 날리는 중 (아직 쿼리 확인을 못함)

TODO : 채팅방 리스트를 가져오는 동작이 2번의 쿼리를 동기적으로 실행해서 오히려 느려질 수 있는 지점이 될 수 있음