### PR TITLE
feat : 채팅방 추가 및 채팅 리스트 조회 구현

### DIFF
--- a/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
@@ -3,23 +3,20 @@ package com.challenge.chat.domain.chat.controller;
 import com.challenge.chat.domain.chat.constant.KafkaConstants;
 import com.challenge.chat.domain.chat.dto.ChatDto;
 import com.challenge.chat.domain.chat.dto.ChatRoomDto;
-import com.challenge.chat.domain.chat.dto.EnterUserDto;
-import com.challenge.chat.domain.chat.dto.request.ChatRoomRequest;
+import com.challenge.chat.domain.chat.dto.request.ChatRoomAddRequest;
+import com.challenge.chat.domain.chat.dto.request.ChatRoomCreateRequest;
 import com.challenge.chat.domain.chat.service.ChatService;
+import com.challenge.chat.domain.chat.service.Producer;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import java.util.List;
 
@@ -30,18 +27,28 @@ import java.util.List;
 public class ChatController {
 
 	private final ChatService chatService;
-	private final SimpMessagingTemplate msgOperation;
-	private final KafkaTemplate<String, ChatDto> kafkaTemplate;
+	private final Producer producer;
 
 	@PostMapping("/chat")
-	public ResponseEntity<Void> createChatRoom(
-		@RequestBody final ChatRoomRequest request,
+	public ResponseEntity<ChatRoomDto> createChatRoom(
+		@RequestBody final ChatRoomCreateRequest request,
 		@AuthenticationPrincipal final User user) {
 
 		log.info("Controller : 채팅방 생성, User의 email은 {} 입니다", user.getUsername());
-		chatService.makeChatRoom(ChatRoomDto.from(request), user);
 
-		return ResponseEntity.status(HttpStatus.OK).body(null);
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(chatService.makeChatRoom(ChatRoomDto.from(request), user.getUsername()));
+	}
+
+	@PostMapping("/chat/room")
+	public ResponseEntity<ChatRoomDto> addChatRoom(
+		@RequestBody final ChatRoomAddRequest request,
+		@AuthenticationPrincipal final User user) {
+
+		log.info("Controller : 채팅방 추가, User의 email은 {} 입니다", user.getUsername());
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(chatService.registerChatRoom(ChatRoomDto.from(request), user.getUsername()));
 	}
 
 	@GetMapping("/chat/room")
@@ -51,47 +58,50 @@ public class ChatController {
 		log.info("Controller : 채팅방 조회, User의 email은 {} 입니다", user.getUsername());
 
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(chatService.getChatRoomList(user));
+			.body(chatService.searchChatRoomList(user.getUsername()));
 	}
 
+	@GetMapping("/chat/{room-id}")
+	public ResponseEntity<List<ChatDto>> showChatList(
+		@PathVariable("room-id") final String roomId,
+		@AuthenticationPrincipal final User user) {
 
-	// 채팅방 채팅 내역 조회
-	@GetMapping("/chat/{roomId}")
-	public ResponseEntity<EnterUserDto> viewChat(@PathVariable String roomId, @AuthenticationPrincipal User user) {
-		log.info("Controller viewChat, 채팅 내역 조회");
+		log.info("Controller : 채팅 내역 조회, User의 email은 {} 입니다", user.getUsername());
+
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(chatService.viewChat(roomId, user.getUsername()));
+			.body(chatService.searchChatList(roomId, user.getUsername()));
 	}
 
-	// 채팅방 입장하기
 	@MessageMapping("/chat/enter")
-	public void enterChatRoom(@RequestBody ChatDto chatDto, SimpMessageHeaderAccessor headerAccessor) throws Exception {
-		log.info("Controller enterChatRoom, 채팅방 입장");
-		msgOperation.convertAndSend(
-				"/topic/chat/room/" + chatDto.getRoomId(),
-				chatService.enterChatRoom(chatDto, headerAccessor));
-		kafkaTemplate.send(KafkaConstants.KAFKA_TOPIC, chatDto).get();
+	public void enterChatRoom(
+		@RequestBody ChatDto chatDto,
+		SimpMessageHeaderAccessor headerAccessor) {
 
+		log.info("Controller : 채팅방 입장");
+
+		producer.send(
+			KafkaConstants.KAFKA_TOPIC,
+			chatService.makeEnterMessageAndSetSessionAttribute(chatDto, headerAccessor));
 	}
 
-	// 채팅방 채팅 보내기
-//	@MessageMapping("/chat/send")
-	@PostMapping("/chat/send")
-	public void sendChatRoom(@RequestBody ChatDto chatDto) throws Exception {
-		log.info("Controller sendChatRoom, 채팅 보내기 {}", chatDto);
+	@MessageMapping("/chat/send")
+	public void sendChatRoom(
+		@RequestBody ChatDto chatDto) {
+
+		log.info("Controller : 채팅 보내기 - {}", chatDto.getMessage());
+
 		chatService.sendChatRoom(chatDto);
-		msgOperation.convertAndSend(
-				"/topic/chat/room/" + chatDto.getRoomId(),
-				chatDto);
-		kafkaTemplate.send(KafkaConstants.KAFKA_TOPIC, chatDto).get();
+		producer.send(
+			KafkaConstants.KAFKA_TOPIC,
+			chatDto
+		);
 	}
 
-	// 채팅방 나가기
-	@EventListener
-	public void webSocketDisconnectListener(SessionDisconnectEvent event) {
-		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
-		log.info("Controller webSocketDisconnectListener, 채팅방 나가기");
-		ChatDto chatDto = chatService.leaveChatRoom(headerAccessor);
-		msgOperation.convertAndSend("/topic/chat/room/" + chatDto.getRoomId(), chatDto);
-	}
+	// @EventListener
+	// public void webSocketDisconnectListener(SessionDisconnectEvent event) {
+	// 	StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+	// 	log.info("Controller webSocketDisconnectListener, 채팅방 나가기");
+	// 	ChatDto chatDto = chatService.leaveChatRoom(headerAccessor);
+	// 	msgOperation.convertAndSend("/topic/chat/room/" + chatDto.getRoomId(), chatDto);
+	// }
 }

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
@@ -4,8 +4,7 @@ import com.challenge.chat.domain.chat.entity.Chat;
 import com.challenge.chat.domain.chat.entity.MessageType;
 import lombok.*;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -15,35 +14,30 @@ import java.util.Date;
 public class ChatDto {
 
 	private MessageType type;
-	private String sender;
-	private String userId;
+	private String nickname;
+	private String email;
 	private String roomId;
 	private String message;
-	@Builder.Default
-	private String date = formatDate();
-
-	// TODO: 사용하지 않는 생성자 삭제여부
-	public ChatDto(MessageType type, String sender, String userId, String roomId, String message) {
-		this.type = type;
-		this.sender = sender;
-		this.userId = userId;
-		this.roomId = roomId;
-		this.message = message;
-	}
+	private Instant createdAt;
 
 	public static ChatDto from(Chat chat) {
 		return new ChatDto(
-				chat.getType(),
-				chat.getSender(),
-				chat.getUserId(),
-				chat.getRoomId(),
-				chat.getMessage()
+			chat.getType(),
+			chat.getSender(),
+			chat.getUserId(),
+			chat.getRoomId(),
+			chat.getMessage(),
+			chat.getCreatedAt()
 		);
 	}
 
-	public static String formatDate(){
-		Date date = new Date();
-		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		return format.format(date);
+	public static Chat toEntity(ChatDto chatDto) {
+		return Chat.of(
+			chatDto.getType(),
+			chatDto.getNickname(),
+			chatDto.getEmail(),
+			chatDto.getRoomId(),
+			chatDto.getMessage()
+		);
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatRoomDto.java
@@ -1,6 +1,7 @@
 package com.challenge.chat.domain.chat.dto;
 
-import com.challenge.chat.domain.chat.dto.request.ChatRoomRequest;
+import com.challenge.chat.domain.chat.dto.request.ChatRoomAddRequest;
+import com.challenge.chat.domain.chat.dto.request.ChatRoomCreateRequest;
 import com.challenge.chat.domain.chat.entity.ChatRoom;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,20 +15,19 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatRoomDto {
-	private String id;
 	private String roomId;
 	private String roomName;
 
-	private ChatRoomDto(String roomName) {
-		this.roomName = roomName;
+	public static ChatRoomDto from(ChatRoomCreateRequest chatRoomCreateRequest) {
+		return new ChatRoomDto(null, chatRoomCreateRequest.getRoomName());
 	}
 
-	public static ChatRoomDto from(ChatRoomRequest request) {
-		return new ChatRoomDto(request.getRoomName());
+	public static ChatRoomDto from(ChatRoomAddRequest chatRoomAddRequest) {
+		return new ChatRoomDto(chatRoomAddRequest.getRoomId(), null);
 	}
 
 	public static ChatRoomDto from(ChatRoom chatRoom) {
-		return new ChatRoomDto(chatRoom.getId(), chatRoom.getRoomId(), chatRoom.getRoomName());
+		return new ChatRoomDto(chatRoom.getRoomId(), chatRoom.getRoomName());
 	}
 
 	public static ChatRoom toEntity(ChatRoomDto dto) {

--- a/src/main/java/com/challenge/chat/domain/chat/dto/request/ChatRoomAddRequest.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/request/ChatRoomAddRequest.java
@@ -1,0 +1,12 @@
+package com.challenge.chat.domain.chat.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ChatRoomAddRequest {
+	private String roomId;
+}

--- a/src/main/java/com/challenge/chat/domain/chat/dto/request/ChatRoomCreateRequest.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/request/ChatRoomCreateRequest.java
@@ -7,6 +7,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class ChatRoomRequest {
+public class ChatRoomCreateRequest {
 	private String roomName;
 }

--- a/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
@@ -1,6 +1,5 @@
 package com.challenge.chat.domain.chat.entity;
 
-import com.challenge.chat.domain.chat.dto.ChatDto;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +7,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
-import java.util.Date;
 
 @Getter
 @Document(collection = "chat")
@@ -30,12 +28,15 @@ public class Chat {
 	@CreatedDate
 	private Instant createdAt;
 
-	public Chat(ChatDto chatDto, MessageType messageType) {
-		this.type = messageType;
-		this.sender = chatDto.getSender();
-		this.userId = chatDto.getUserId();
-		this.roomId = chatDto.getRoomId();
-		this.message = chatDto.getMessage();
-//		this.createdAt = chatDto.getDate();
+	private Chat(MessageType type, String sender, String userId, String roomId, String message) {
+		this.type = type;
+		this.sender = sender;
+		this.userId = userId;
+		this.roomId = roomId;
+		this.message = message;
+	}
+
+	public static Chat of(MessageType type, String sender, String userId, String roomId, String message) {
+		return new Chat(type, sender, userId, roomId, message);
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/repository/MemberChatRoomRepository.java
+++ b/src/main/java/com/challenge/chat/domain/chat/repository/MemberChatRoomRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface MemberChatRoomRepository extends MongoRepository<MemberChatRoom, String> {
 
-	Optional<MemberChatRoom> findByMemberEmailAndRoomId(String memberId, String roomId);
+	Optional<MemberChatRoom> findByMemberEmailAndRoomId(String memberEmail, String roomId);
 
 	Optional<List<MemberChatRoom>> findByMemberEmail(String email);
 }

--- a/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
@@ -2,7 +2,6 @@ package com.challenge.chat.domain.chat.service;
 
 import com.challenge.chat.domain.chat.dto.ChatDto;
 import com.challenge.chat.domain.chat.dto.ChatRoomDto;
-import com.challenge.chat.domain.chat.dto.EnterUserDto;
 import com.challenge.chat.domain.chat.entity.Chat;
 import com.challenge.chat.domain.chat.entity.ChatRoom;
 import com.challenge.chat.domain.chat.entity.MemberChatRoom;
@@ -10,8 +9,6 @@ import com.challenge.chat.domain.chat.entity.MessageType;
 import com.challenge.chat.domain.chat.repository.ChatRepository;
 import com.challenge.chat.domain.chat.repository.ChatRoomRepository;
 import com.challenge.chat.domain.chat.repository.MemberChatRoomRepository;
-import com.challenge.chat.domain.member.entity.Member;
-import com.challenge.chat.domain.member.service.MemberService;
 import com.challenge.chat.exception.RestApiException;
 import com.challenge.chat.exception.dto.ChatErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -21,44 +18,53 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 @Slf4j
 public class ChatService {
 
 	private final MemberChatRoomRepository memberChatRoomRepository;
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatRepository chatRepository;
-	private final MemberService memberService;
 	private final MongoTemplate mongoTemplate;
 
-	public void makeChatRoom(final ChatRoomDto chatRoomDto, final User user) {
+	@Transactional
+	public ChatRoomDto makeChatRoom(final ChatRoomDto chatRoomDto, final String memberEmail) {
 		log.info("Service : 채팅방 생성");
 
 		ChatRoom chatRoom = ChatRoomDto.toEntity(chatRoomDto);
 
-		// TODO : 비동기적으로 chatRoom 과 memberchatRoom을 저장하기
+		// TODO : 비동기적으로 chatRoom 과 memberChatRoom을 저장하기
 		chatRoomRepository.save(chatRoom);
-		memberChatRoomRepository.save(new MemberChatRoom(chatRoom.getRoomId(), user.getUsername()));
+		memberChatRoomRepository.save(new MemberChatRoom(chatRoom.getRoomId(), memberEmail));
+
+		return ChatRoomDto.from(chatRoom);
+	}
+
+	@Transactional
+	public ChatRoomDto registerChatRoom(final ChatRoomDto chatRoomDto, final String memberEmail) {
+		log.info("Service : 채팅방 추가");
+
+		ChatRoom chatRoom = findChatRoom(chatRoomDto.getRoomId());
+		memberChatRoomRepository.save(new MemberChatRoom(chatRoomDto.getRoomId(), memberEmail));
+
+		return ChatRoomDto.from(chatRoom);
 	}
 
 	@Transactional(readOnly = true)
-	public List<ChatRoomDto> getChatRoomList(final User user) {
+	public List<ChatRoomDto> searchChatRoomList(final String memberEmail) {
 		log.info("Service : 채팅방 리스트 조회");
 
 		// TODO : 채팅방 리스트를 가져오는 동작이 2번의 쿼리를 동기적으로 실행해서 오히려 느려질 수 있는 지점이 될 수 있음
-		List<String> roomIds = findChatRoomId(user.getUsername());
+		List<String> roomIds = findChatRoomId(memberEmail);
 
 		Query query = new Query(Criteria.where("roomId").in(roomIds));
 		return mongoTemplate.find(query, ChatRoom.class)
@@ -67,29 +73,43 @@ public class ChatService {
 			.collect(Collectors.toList());
 	}
 
+	@Transactional(readOnly = true)
+	public List<ChatDto> searchChatList(final String roomId, final String memberEmail) {
+		log.info("Service : 채팅방 메세지 조회");
 
-	// 채팅방 입장
-	public ChatDto enterChatRoom(ChatDto chatDto, SimpMessageHeaderAccessor headerAccessor) {
-		log.info("Service 채팅방 입장");
+		MemberChatRoom memberChatRoom = findMemberChatRoom(roomId, memberEmail);
 
-		ChatRoom chatRoom = getRoomByRoomId(chatDto.getRoomId());
-		Member member = memberService.findMemberByEmail(chatDto.getUserId());
-		// 중간 테이블 생성
-		Optional<MemberChatRoom> memberChatRoom = memberChatRoomRepository.findByMemberEmailAndRoomId(member.getEmail(), chatRoom.getRoomId());
-		if (memberChatRoom.isEmpty()) {
-			memberChatRoomRepository.save(new MemberChatRoom(chatRoom.getRoomId(), member.getEmail()));
+		return chatRepository
+			.findByRoomId(roomId)
+			.stream()
+			.sorted(Comparator.comparing(Chat::getCreatedAt))
+			.map(ChatDto::from)
+			.toList();
+	}
+
+	public ChatDto makeEnterMessageAndSetSessionAttribute(ChatDto chatDto, SimpMessageHeaderAccessor headerAccessor) {
+		log.info("Service : 채팅방 입장");
+
+		// socket session에 사용자의 정보 저장
+		try {
+			Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("email", chatDto.getEmail());
+		} catch (Exception e) {
+			throw new RestApiException(ChatErrorCode.SOCKET_CONNECTION_ERROR);
 		}
-		//반환 결과를 socket session 에 사용자의 id로 저장
-		Objects.requireNonNull(headerAccessor.getSessionAttributes()).put("userId", chatDto.getUserId());
 		headerAccessor.getSessionAttributes().put("roomId", chatDto.getRoomId());
-		headerAccessor.getSessionAttributes().put("nickName", chatDto.getSender());
-		chatDto.setMessage(chatDto.getSender() + "님 입장!! ο(=•ω＜=)ρ⌒☆");
+		headerAccessor.getSessionAttributes().put("nickname", chatDto.getNickname());
+
+		chatDto.setMessage(chatDto.getNickname() + "님 입장!! ο(=•ω＜=)ρ⌒☆");
 
 		return chatDto;
 	}
 
-	// 채팅방 나가기
-	@Transactional(readOnly = true)
+	public void sendChatRoom(ChatDto chatDto) {
+		log.info("Service : 채팅 보내기 - {}", chatDto.getMessage());
+
+		chatRepository.save(ChatDto.toEntity(chatDto));
+	}
+
 	public ChatDto leaveChatRoom(SimpMessageHeaderAccessor headerAccessor) {
 		log.info("Service 채팅방 나가기");
 
@@ -100,51 +120,24 @@ public class ChatService {
 		return ChatDto.builder()
 			.type(MessageType.LEAVE)
 			.roomId(roomId)
-			.sender(nickName)
-			.userId(userId)
+			.nickname(nickName)
+			.email(userId)
 			.message(nickName + "님 퇴장!! ヽ(*。>Д<)o゜")
 			.build();
 	}
 
-	// 채팅 메세지 조회
-	@Transactional(readOnly = true)
-	public EnterUserDto viewChat(String roomId, String email) {
-		log.info("Service 채팅방 메세지 조회");
-
-		ChatRoom chatRoom = getRoomByRoomId(roomId);
-		Member member = memberService.findMemberByEmail(email);
-
-		List<ChatDto> chatDtoList = chatRepository
-				.findByRoomId(chatRoom.getRoomId())
-				.stream()
-				.sorted(Comparator.comparing(Chat::getCreatedAt))
-				.map(ChatDto::from) // Using the from() method as a method reference
-				.toList();
-
-		return new EnterUserDto(member.getNickname(), member.getEmail(), chatRoom.getRoomId(), chatDtoList);
-	}
-
-	// 채팅 보내기
-	public void sendChatRoom(ChatDto chatDto) {
-		log.info("Service 채팅 SEND");
-
-//		isRoomExist(chatDto.getRoomId());
-
-		Chat chat = new Chat(chatDto, MessageType.TALK);
-		chatRepository.save(chat);
-	}
-
-	public ChatRoom getRoomByRoomId(String roomId) {
+	public ChatRoom findChatRoom(String roomId) {
 		return chatRoomRepository.findByRoomId(roomId).orElseThrow(
 			() -> new RestApiException(ChatErrorCode.CHATROOM_NOT_FOUND));
 	}
 
-	public void isRoomExist(String roomId) {
-		chatRoomRepository.findByRoomId(roomId).orElseThrow(
-				() -> new RestApiException(ChatErrorCode.CHATROOM_NOT_FOUND));
+	public MemberChatRoom findMemberChatRoom(final String roomId, final String memberEmail) {
+		return memberChatRoomRepository.findByMemberEmailAndRoomId(memberEmail, roomId).orElseThrow(
+			() -> new RestApiException(ChatErrorCode.CHATROOM_NOT_FOUND)
+		);
 	}
 
-	public List<String> findChatRoomId(String email) {
+	public List<String> findChatRoomId(final String email) {
 		List<MemberChatRoom> memberChatRoomList = memberChatRoomRepository.findByMemberEmail(email).orElse(null);
 		if (memberChatRoomList == null) {
 			return null;

--- a/src/main/java/com/challenge/chat/domain/chat/service/Consumer.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/Consumer.java
@@ -17,14 +17,14 @@ public class Consumer {
      * Message를 작성할 때 경로 잘 보고 import
      */
     @Autowired
-    SimpMessagingTemplate template;
+    SimpMessagingTemplate msgOperation;
 
     @KafkaListener(
             topics = KafkaConstants.KAFKA_TOPIC,
             groupId = KafkaConstants.GROUP_ID
     )
-    public void consume(ChatDto ChatDto) {
-        log.info("난 컨슈머야 message={}", ChatDto);
-        template.convertAndSend("/topic/chat/room", ChatDto);
+    public void consume(ChatDto chatDto) {
+        log.info("난 컨슈머야 message={}", chatDto);
+        msgOperation.convertAndSend("/topic/chat/room" + chatDto.getRoomId(), chatDto);
     }
 }

--- a/src/main/java/com/challenge/chat/domain/chat/service/Producer.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/Producer.java
@@ -1,6 +1,9 @@
 package com.challenge.chat.domain.chat.service;
 
 import com.challenge.chat.domain.chat.dto.ChatDto;
+import com.challenge.chat.exception.RestApiException;
+import com.challenge.chat.exception.dto.ChatErrorCode;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -15,7 +18,11 @@ public class Producer {
 
     public void send(String topic, ChatDto data) {
         log.info("sending data='{}' to topic='{}'", data, topic);
-        kafkaTemplate.send(topic, data); // send to react clients via websocket (STOMP)
+        try {
+            kafkaTemplate.send(topic, data).get(); // send to react clients via websocket (STOMP)
+        } catch (Exception e) {
+            throw new RestApiException(ChatErrorCode.KAFKA_PRODUCER_ERROR);
+        }
     }
 }
 

--- a/src/main/java/com/challenge/chat/exception/dto/ChatErrorCode.java
+++ b/src/main/java/com/challenge/chat/exception/dto/ChatErrorCode.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum ChatErrorCode implements ErrorCode {
 
 	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다"),
+	KAFKA_PRODUCER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "채팅 전송에 실패했습니다"),
+	KAFKA_CONSUMER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "채팅 수신에 실패했습니다"),
+	SOCKET_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "소켓 통신이 불안정 합니다"),
 	;
 
 	private final HttpStatus httpStatus;


### PR DESCRIPTION
1. 채팅방 추가
- 신규 기능 : roomId를 통해 채팅방에 참여하는 기능. MemberChatRoom을 새롭게 추가한다.

2. 채팅방 채팅 리스트 조회
- 굳이 필요 없는 검증 로직 제거 ex)채팅방, 유저 존재 여부

3. 소켓 통신
- Controller에서 KafkaTemplate을 Producer로 리팩토링
- webSocketDisconnectListener 주석 처리. 채팅방 이동간 소켓 통신 disconnect를 하지 않기로 함.

4. DTO의 id 필드 제거
- mongoDB document의 ObjectId를 필드로 응답해주고 있었는데 굳이 그럴 필요가 없는 것 같아 제거

5. Exception 처리
- 세션 정보를 받지 못했을 때 or 카프카에 정보 전달을 제대로 하지 못했을 때 exception 처리