### PR TITLE
feat : 채팅 반환시 imageUrl 추가, createdAt 변환 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ jib {
     }
     to {
         image = 'chat-challenge'
-        tags = ['0.7']
+        tags = ['0.9']
     }
     container {
         mainClass = 'com.challenge.chat.ChatApplication'
@@ -76,6 +76,9 @@ dependencies {
 // https://mvnrepository.com/artifact/org.springframework.amqp/spring-rabbit
 //    implementation 'org.springframework.boot:spring-boot-starter-amqp:2.6.4'
 //    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty:2.6.4'
+
+    // Elasticsearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/challenge/chat/ChatApplication.java
+++ b/src/main/java/com/challenge/chat/ChatApplication.java
@@ -2,14 +2,23 @@ package com.challenge.chat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.elasticsearch.config.EnableElasticsearchAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@EnableMongoAuditing
-@SpringBootApplication
+import com.challenge.chat.domain.chat.repository.ChatRepository;
+import com.challenge.chat.domain.chat.repository.ChatSearchRepository;
+
+@EnableElasticsearchAuditing
 @EnableJpaAuditing
-@EnableMongoRepositories(basePackages = {"com.challenge.chat.domain.chat.repository", "com.challenge.chat.domain.member.repository"} )
+@EnableJpaRepositories(excludeFilters = @ComponentScan.Filter(
+	type = FilterType.ASSIGNABLE_TYPE,
+	classes = {ChatSearchRepository.class, ChatRepository.class}))
+@EnableMongoRepositories(basePackageClasses = {ChatRepository.class})
+@SpringBootApplication
 public class ChatApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/challenge/chat/config/ElasticSearchConfig.java
+++ b/src/main/java/com/challenge/chat/config/ElasticSearchConfig.java
@@ -1,0 +1,23 @@
+package com.challenge.chat.config;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+import com.challenge.chat.domain.chat.repository.ChatSearchRepository;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackageClasses = {ChatSearchRepository.class})
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+	@Override
+	public RestHighLevelClient elasticsearchClient() {
+		// http port 와 통신할 주소
+		ClientConfiguration configuration = ClientConfiguration.builder()
+			.connectedTo("es:9200")
+			.build();
+		return RestClients.create(configuration).rest();
+	}
+}

--- a/src/main/java/com/challenge/chat/config/SecurityConfig.java
+++ b/src/main/java/com/challenge/chat/config/SecurityConfig.java
@@ -154,6 +154,7 @@ public class SecurityConfig {
 
 		CorsConfiguration config = new CorsConfiguration();
 		config.addAllowedOrigin("http://localhost:3000");
+		config.addAllowedOrigin("http://this.code.s3-website-us-east-1.amazonaws.com");
 		config.addExposedHeader("Authorization");
 		config.addExposedHeader("Authorization-refresh");
 

--- a/src/main/java/com/challenge/chat/domain/chat/config/ConsumerConfig.java
+++ b/src/main/java/com/challenge/chat/domain/chat/config/ConsumerConfig.java
@@ -1,7 +1,7 @@
 package com.challenge.chat.domain.chat.config;
 
 import com.challenge.chat.domain.chat.constant.KafkaConstants;
-import com.challenge.chat.domain.chat.entity.Chat;
+import com.challenge.chat.domain.chat.dto.ChatDto;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.context.annotation.Bean;
@@ -25,15 +25,15 @@ public class ConsumerConfig {
      * AUTO_OFFSET_RESET_CONFIG에는 latest(가장 최근에 생성된 메시지를 offset reset), earliest(가장 오래된 메시지를), none의 값을 입력할 수 있음
      */
     @Bean
-    ConcurrentKafkaListenerContainerFactory<String, Chat> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, Chat> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    ConcurrentKafkaListenerContainerFactory<String, ChatDto> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChatDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }
 
     @Bean
-    public ConsumerFactory<String, Chat> consumerFactory() {
-        return new DefaultKafkaConsumerFactory<>(consumerConfigurations(), new StringDeserializer(), new JsonDeserializer<>(Chat.class));
+    public ConsumerFactory<String, ChatDto> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations(), new StringDeserializer(), new JsonDeserializer<>(ChatDto.class));
     }
 
     @Bean

--- a/src/main/java/com/challenge/chat/domain/chat/config/ProducerConfig.java
+++ b/src/main/java/com/challenge/chat/domain/chat/config/ProducerConfig.java
@@ -1,6 +1,7 @@
 package com.challenge.chat.domain.chat.config;
 
 import com.challenge.chat.domain.chat.constant.KafkaConstants;
+import com.challenge.chat.domain.chat.dto.ChatDto;
 import com.challenge.chat.domain.chat.entity.Chat;
 
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -27,7 +28,7 @@ public class ProducerConfig {
      * properties나 yaml으로 설정할 수도 있고, 아래처럼 @Bean으로 설정해줄 수도 있음
      */
     @Bean
-    public ProducerFactory<String, Chat> producerFactory() {
+    public ProducerFactory<String, ChatDto> producerFactory() {
         return new DefaultKafkaProducerFactory<>(producerConfigurations());
     }
 
@@ -41,7 +42,7 @@ public class ProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, Chat> kafkaTemplate() {
+    public KafkaTemplate<String, ChatDto> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
@@ -73,7 +73,7 @@ public class ChatController {
 			.body(chatService.searchChatList(roomCode, user.getUsername()));
 	}
 
-	@MessageMapping("chat.enter")
+	@MessageMapping("/chat/enter")
 	public void enterChatRoom(
 		@RequestBody ChatDto chatDto,
 		SimpMessageHeaderAccessor headerAccessor) {
@@ -88,7 +88,7 @@ public class ChatController {
 		// rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, "room." + newChatDto.getRoomCode(), newChatDto);
 	}
 
-	@MessageMapping("chat.send")
+	@MessageMapping("/chat/send")
 	public void sendChatRoom(
 		@RequestBody ChatDto chatDto) {
 

--- a/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
@@ -5,14 +5,12 @@ import com.challenge.chat.domain.chat.dto.ChatDto;
 import com.challenge.chat.domain.chat.dto.ChatRoomDto;
 import com.challenge.chat.domain.chat.dto.request.ChatRoomAddRequest;
 import com.challenge.chat.domain.chat.dto.request.ChatRoomCreateRequest;
-import com.challenge.chat.domain.chat.entity.Chat;
 import com.challenge.chat.domain.chat.service.ChatService;
 import com.challenge.chat.domain.chat.service.Producer;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-// import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -81,7 +79,7 @@ public class ChatController {
 		ChatDto newChatDto = chatService.makeEnterMessageAndSetSessionAttribute(chatDto, headerAccessor);
 		// producer.send(
 		// 	KafkaConstants.KAFKA_TOPIC,
-		// 	newChatDto
+		// 	newchatDto
 		// );
 
 		msgOperation.convertAndSend("/topic/chat/room/" + chatDto.getRoomCode(), newChatDto);
@@ -92,16 +90,24 @@ public class ChatController {
 	public void sendChatRoom(
 		@RequestBody ChatDto chatDto) {
 
-		Chat chat = ChatDto.toEntity(chatDto);
-		chat.setCreatedAt(chatDto.getCreatedAt());
-
 		producer.send(
 			KafkaConstants.KAFKA_TOPIC,
-			chat
+			chatDto
 		);
 		// rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, "room." + chatDto.getRoomCode(), chatDto);
 		// chatService.sendChatRoom(chatDto);
 		msgOperation.convertAndSend("/topic/chat/room/" + chatDto.getRoomCode(), chatDto);
+	}
+
+	@GetMapping("/chat/{room-code}/{message}")
+	public ResponseEntity<List<ChatDto>> searchChatList(
+		@PathVariable("room-code") final String roomCode,
+		@PathVariable("message") final String message) {
+
+		log.info("Controller : 채팅 메시지 검색");
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(chatService.findChatList(roomCode, message));
 	}
 
 	// @EventListener

--- a/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/challenge/chat/domain/chat/controller/ChatController.java
@@ -93,7 +93,7 @@ public class ChatController {
 		@RequestBody ChatDto chatDto) {
 
 		Chat chat = ChatDto.toEntity(chatDto);
-		// chat.setCreatedAt(chatDto.getCreatedAt());
+		chat.setCreatedAt(chatDto.getCreatedAt());
 
 		producer.send(
 			KafkaConstants.KAFKA_TOPIC,

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
@@ -40,4 +40,16 @@ public class ChatDto {
 			chatDto.getMessage()
 		);
 	}
+
+	public static ChatDto from(ChatES chat) {
+		return new ChatDto(
+			chat.getType(),
+			chat.getNickname(),
+			chat.getEmail(),
+			chat.getRoomCode(),
+			chat.getMessage(),
+			Instant.ofEpochMilli(chat.getCreatedAt()),
+			chat.getImageUrl()
+		);
+	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
+++ b/src/main/java/com/challenge/chat/domain/chat/dto/ChatDto.java
@@ -1,6 +1,7 @@
 package com.challenge.chat.domain.chat.dto;
 
 import com.challenge.chat.domain.chat.entity.Chat;
+import com.challenge.chat.domain.chat.entity.ChatES;
 import com.challenge.chat.domain.chat.entity.MessageType;
 import lombok.*;
 
@@ -19,15 +20,29 @@ public class ChatDto {
 	private String roomCode;
 	private String message;
 	private Instant createdAt;
+	private String imageUrl;
 
 	public static ChatDto from(Chat chat) {
+
+		Instant instant;
+		if (chat.getCreatedAt() == null) {
+			instant = null;
+		} else {
+			double timestampValue = Double.parseDouble(chat.getCreatedAt());
+			long epochSeconds = (long) timestampValue;
+			instant = Instant.ofEpochSecond(
+				epochSeconds,
+				(int) ((timestampValue - epochSeconds) * 1_000_000_000));
+		}
+
 		return new ChatDto(
 			chat.getType(),
 			chat.getNickname(),
 			chat.getEmail(),
 			chat.getRoomCode(),
 			chat.getMessage(),
-			Instant.ofEpochMilli(chat.getCreatedAt())
+			instant,
+			chat.getImageUrl()
 		);
 	}
 

--- a/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
@@ -7,9 +7,11 @@ import lombok.Setter;
 
 import java.time.Instant;
 
+import org.springframework.data.mongodb.core.mapping.Document;
+
 @Getter
 @Setter
-// @Document(collection = "chat")
+@Document(collection = "chat")
 @NoArgsConstructor
 @AllArgsConstructor
 public class Chat {
@@ -27,7 +29,9 @@ public class Chat {
 	private String message;
 
 	// @CreatedDate
-	private long createdAt;
+	private String createdAt;
+
+	private String imageUrl;
 
 	private Chat(MessageType type, String nickname, String email, String roomCode, String message) {
 		this.type = type;
@@ -39,13 +43,5 @@ public class Chat {
 
 	public static Chat of(MessageType type, String nickname, String email, String roomCode, String message) {
 		return new Chat(type, nickname, email, roomCode, message);
-	}
-
-	public void setCreatedAt(Instant time) {
-		if (time == null) {
-			this.createdAt = Instant.now().toEpochMilli();
-			return;
-		}
-		this.createdAt = time.toEpochMilli();
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/Chat.java
@@ -42,6 +42,10 @@ public class Chat {
 	}
 
 	public void setCreatedAt(Instant time) {
+		if (time == null) {
+			this.createdAt = Instant.now().toEpochMilli();
+			return;
+		}
 		this.createdAt = time.toEpochMilli();
 	}
 }

--- a/src/main/java/com/challenge/chat/domain/chat/entity/ChatES.java
+++ b/src/main/java/com/challenge/chat/domain/chat/entity/ChatES.java
@@ -1,0 +1,56 @@
+package com.challenge.chat.domain.chat.entity;
+
+import java.time.Instant;
+
+import javax.persistence.Id;
+
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Mapping(mappingPath = "elastic/chat-mapping.json")
+@Setting(settingPath = "elastic/chat-setting.json")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Document(indexName = "kafka-chat")
+public class ChatES {
+
+	@Id
+	private String id;
+
+	private MessageType type;
+
+	private String nickname;
+
+	private String email;
+
+	private String roomCode;
+
+	private String message;
+
+	@Field(type = FieldType.Date, format = {DateFormat.date_hour_minute_second_millis, DateFormat.epoch_millis})
+	private long createdAt;
+
+	private String imageUrl;
+
+
+	// @Builder
+	// public ChatES(String id, MessageType type, String nickname, String email, String roomCode, String message,
+	// 	Instant createdAt) {
+	// 	this.id = id;
+	// 	this.type = type;
+	// 	this.nickname = nickname;
+	// 	this.email = email;
+	// 	this.roomCode = roomCode;
+	// 	this.message = message;
+	// 	this.createdAt = createdAt;
+	// }
+}

--- a/src/main/java/com/challenge/chat/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/challenge/chat/domain/chat/repository/ChatRepository.java
@@ -10,4 +10,6 @@ public interface ChatRepository extends MongoRepository<Chat, String> {
     // Spring Data MongoDB -> https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/
 
     Optional<List<Chat>> findByRoomCode(String roomCode);
+
+    Optional<List<Chat>> findByRoomCodeAndMessageContaining(String roomCode, String message);
 }

--- a/src/main/java/com/challenge/chat/domain/chat/repository/ChatSearchRepository.java
+++ b/src/main/java/com/challenge/chat/domain/chat/repository/ChatSearchRepository.java
@@ -1,0 +1,13 @@
+package com.challenge.chat.domain.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import com.challenge.chat.domain.chat.entity.ChatES;
+
+public interface ChatSearchRepository extends ElasticsearchRepository<ChatES, String> {
+
+	List<ChatES> findByMessage(String message);
+}

--- a/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/ChatService.java
@@ -16,7 +16,8 @@ import com.challenge.chat.exception.RestApiException;
 import com.challenge.chat.exception.dto.ChatErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.MongoTemplate;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,13 +78,10 @@ public class ChatService {
 
 	@Transactional(readOnly = true)
 	public List<ChatDto> searchChatList(final String roomCode, final String memberEmail) {
-		ChatRoom chatRoom = findChatRoom(roomCode);
-		List<Chat> chatList = chatRepository.findByRoomCode(roomCode).orElse(null);
-		if (chatList == null) {
-			return null;
-		}
-		return chatList
-			.stream()
+
+		List<Chat> chatList = chatRepository.findByRoomCode(roomCode).orElse(Collections.emptyList());
+
+		return chatList.stream()
 			.map(ChatDto::from)
 			.sorted(Comparator.comparing(ChatDto::getCreatedAt))
 			.collect(Collectors.toList());

--- a/src/main/java/com/challenge/chat/domain/chat/service/Producer.java
+++ b/src/main/java/com/challenge/chat/domain/chat/service/Producer.java
@@ -1,5 +1,6 @@
 package com.challenge.chat.domain.chat.service;
 
+import com.challenge.chat.domain.chat.dto.ChatDto;
 import com.challenge.chat.domain.chat.entity.Chat;
 import com.challenge.chat.exception.RestApiException;
 import com.challenge.chat.exception.dto.ChatErrorCode;
@@ -14,9 +15,9 @@ import org.springframework.stereotype.Component;
 public class Producer {
 
     @Autowired
-    private KafkaTemplate<String, Chat> kafkaTemplate;
+    private KafkaTemplate<String, ChatDto> kafkaTemplate;
 
-    public void send(String topic, Chat data) {
+    public void send(String topic, ChatDto data) {
         log.info("sending data='{}' to topic='{}'", data, topic);
         try {
             kafkaTemplate.send(topic, data).get(); // send to react clients via websocket (STOMP)

--- a/src/main/java/com/challenge/chat/security/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/challenge/chat/security/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -70,7 +70,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 		jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
 //		jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
 
-		String redirectUrl = "http://localhost:3000/userslist?" + "Authorization" + "=" +
+		String redirectUrl = "http://this.code.s3-website-us-east-1.amazonaws.com/userslist?" + "Authorization" + "=" +
 			URLEncoder.encode("Bearer " + accessToken, "UTF-8") +
 			"&" + "Authorization-refresh" + "=" + URLEncoder.encode("Bearer " + refreshToken, "UTF-8");
 		response.sendRedirect(redirectUrl);

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -12,3 +12,6 @@ jwt:
   refresh:
     expiration: 604800000 #  (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h) * 24L(h -> 하루) * 14(2주))
     header: Authorization-refresh
+logging:
+  level:
+    org.springframework.data.elasticsearch.client.WIRE: TRACE

--- a/src/main/resources/elastic/chat-mapping.json
+++ b/src/main/resources/elastic/chat-mapping.json
@@ -1,0 +1,13 @@
+{
+  "properties" : {
+    "type" : {"type" : "text"},
+    "nickname" : {"type" : "text"},
+    "email" : {"type" : "text"},
+    "roomCode" : {"type" : "text"},
+    "message" : {"type" : "text", "analyzer" : "korean"},
+    "createdAt" : {
+      "type" : "date"
+    },
+    "imageUrl" : {"type" : "text"}
+  }
+}

--- a/src/main/resources/elastic/chat-setting.json
+++ b/src/main/resources/elastic/chat-setting.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}


### PR DESCRIPTION
배포까지 수정되었던 내역들 한 번에 pr 보냅니다.

중요한 내용은
- createdAt이 mongodb에 kafka connector로 저장될 때 특수한 값으로 저장되어 조회할 때 변환하는 로직을 추가
- elasticsearch 관련 코드 추가
- 배포한 도메인 주소 cors 허용
- es 검색 기능이 잘 동작했었는데 그렇지 않게 되어 mongodb로 변경해놓음